### PR TITLE
fix(pix-display): keep editor cursor visible in restyleMarkers

### DIFF
--- a/packages/pix-display/src/paste-chips.ts
+++ b/packages/pix-display/src/paste-chips.ts
@@ -149,11 +149,20 @@ export function replaceImagePaths(
  *
  * Width-preserving is not required — Pi re-wraps each render call.
  */
+// A `[...]` span that starts with `paste #` and may carry interleaved cursor
+// SGR codes (e.g. `[paste #1 \x1b[7m5\x1b[0m8 chars]`). We strip ANSI from the
+// matched span only, never the whole line, so the editor cursor's own
+// inverse-video block outside any marker survives.
+const MARKER_SPAN_RE =
+	/(?:\x1b\[[0-9;]*m)*\[(?:\x1b\[[0-9;]*m)*paste #(?:[^\]]|\x1b\[[0-9;]*m)*\]/g;
+
 export function restyleMarkers(line: string, imageIds: Set<number>): string {
-	// Strip cursor inversion codes the TUI embeds when the cursor
-	// intersects a marker — plain MARKER_RE handles the rest.
-	const clean = line.includes("\x1b") ? line.replace(CURSOR_RE, "") : line;
-	return clean.replace(MARKER_RE, (_full, idStr, _g2, _g3, linesStr, charsStr) => {
+	return line.replace(MARKER_SPAN_RE, (span) => {
+		const clean = span.includes("\x1b") ? span.replace(CURSOR_RE, "") : span;
+		MARKER_RE.lastIndex = 0;
+		const m = MARKER_RE.exec(clean);
+		if (!m?.[1]) return span;
+		const [, idStr, , , linesStr, charsStr] = m;
 		const id = Number.parseInt(idStr, 10);
 		if (imageIds.has(id)) {
 			return chip(FG_BLUE, icon("paste.image"), "image", `#${id}`);

--- a/packages/pix-display/test/paste-chips.test.ts
+++ b/packages/pix-display/test/paste-chips.test.ts
@@ -71,6 +71,18 @@ describe("paste-chips restyleMarkers", () => {
 		it("returns empty string unchanged", () => {
 			expect(restyleMarkers("", new Set())).toBe("");
 		});
+
+		it("preserves the editor cursor's inverse-video block on a non-marker line", () => {
+			// The TUI draws the input cursor as \x1b[7m<char>\x1b[27m. A marker-free
+			// line must pass through untouched so the cursor stays visible.
+			const line = "hello \x1b[7m \x1b[27mworld";
+			expect(restyleMarkers(line, new Set())).toBe(line);
+		});
+
+		it("preserves an end-of-line cursor block (empty input)", () => {
+			const line = "\x1b[7m \x1b[27m";
+			expect(restyleMarkers(line, new Set())).toBe(line);
+		});
 	});
 
 	describe("ANSI-styled markers", () => {


### PR DESCRIPTION
restyleMarkers() stripped every SGR code from the whole input line via line.replace(CURSOR_RE, ""), which also removed the TUI editor cursors own inverse-video block (ESC[7m…ESC[27m). Pi-tui hides the hardware cursor and relies solely on that inverse block to show the caret, so the main-editor input cursor became invisible (noticeable in Windows Terminal). The pix-ask input uses a different input path and was unaffected, which helped localize it.

## Fix
Strip cursor SGR codes only inside a matched paste-marker span, never the whole line. A marker-free line (e.g. one carrying just the cursor block, including at end of an empty input) now passes through untouched, so the cursor stays visible. Markers with embedded cursor codes still restyle correctly.

## Tests
- All existing paste-chips tests pass (markers with cursor codes inside/at brackets still restyle).
- Adds 2 regression tests: cursor inverse-video block preserved on a non-marker line, and at end of empty input.

typecheck + biome clean.