### PR TITLE
fix(pix-9router): handle capabilities nesting from 9router v1 API

### DIFF
--- a/packages/pix-9router/src/data.ts
+++ b/packages/pix-9router/src/data.ts
@@ -41,6 +41,12 @@ export interface RouterModel {
 	max_tokens?: number;
 	maxTokens?: number;
 	owned_by?: string;
+	/** 9router v1 API nests these inside capabilities */
+	capabilities?: {
+		contextWindow?: number;
+		maxOutput?: number;
+		[key: string]: unknown;
+	};
 }
 
 interface RouterModelsResponse {

--- a/packages/pix-9router/src/provider.ts
+++ b/packages/pix-9router/src/provider.ts
@@ -46,13 +46,20 @@ function getContextWindow(model: RouterModel, devModel?: ModelsDevModel): number
 	return (
 		model.context_window ||
 		model.contextWindow ||
+		model.capabilities?.contextWindow ||
 		devModel?.limit?.context ||
 		DEFAULT_CONTEXT_WINDOW
 	);
 }
 
 function getMaxTokens(model: RouterModel, devModel?: ModelsDevModel): number {
-	return model.max_tokens || model.maxTokens || devModel?.limit?.output || DEFAULT_MAX_TOKENS;
+	return (
+		model.max_tokens ||
+		model.maxTokens ||
+		model.capabilities?.maxOutput ||
+		devModel?.limit?.output ||
+		DEFAULT_MAX_TOKENS
+	);
 }
 
 function getReasoning(model: RouterModel, devModel?: ModelsDevModel): boolean {


### PR DESCRIPTION
## Problem

The pix-9router extension was not properly reading `maxOutput` and `contextWindow` values from the 9router API's nested `capabilities` object. The 9router API returns these values inside a `capabilities` object, but the provider only checked top-level fields (`max_tokens`, `maxTokens`, `context_window`, `contextWindow`).

### Impact
For example, model `alims-intl/qwen3-coder-flash-2025-07-28`:
- Actual capability: **maxOutput = 64000** tokens, **contextWindow = 1000000**
- Pi was sending: **max_tokens = 16384** (default fallback), **context_window = 128000** (wrong)

## Solution

1. **data.ts** — Added `capabilities` field to `RouterModel` interface
2. **provider.ts** — Updated `getContextWindow()` and `getMaxTokens()` to read from `model.capabilities?.contextWindow` and `model.capabilities?.maxOutput` as fallbacks before falling to defaults.

All existing fallbacks (top-level fields, modelgrep) are preserved — `capabilities` is just another fallback in the chain.