### PR TITLE
fix(pix-optimizer): recognize Kitty-protocol arrow/escape keys in /optimizer overlay

### DIFF
--- a/packages/pix-optimizer/src/opt.ts
+++ b/packages/pix-optimizer/src/opt.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { matchesKey } from "@earendil-works/pi-tui";
 import { frameLines } from "@xynogen/pix-pretty/modal-frame";
 import type { OptimizerHandle, OptimizerStatus, OptimizerTool } from "./status.ts";
 import { toolIcon } from "./status.ts";
@@ -166,12 +167,12 @@ export function registerOptCommand(
 						},
 						invalidate: () => {},
 						handleInput: (data: string) => {
-							if (data === "k" || data === "\u001b[A") move(-1);
-							else if (data === "j" || data === "\u001b[B") move(1);
-							else if (data === "h" || data === "\u001b[D") cycle(-1);
-							else if (data === "l" || data === "\u001b[C" || data === " " || data === "\r")
+							if (data === "k" || matchesKey(data, "up")) move(-1);
+							else if (data === "j" || matchesKey(data, "down")) move(1);
+							else if (data === "h" || matchesKey(data, "left")) cycle(-1);
+							else if (data === "l" || matchesKey(data, "right") || data === " " || data === "\r")
 								cycle(1);
-							else if (data === "\u001b" || data === "q") {
+							else if (matchesKey(data, "escape") || data === "q") {
 								done(null);
 								return;
 							} else return;


### PR DESCRIPTION
Hello I am working on Ghostty and I encountered an issue with keybindings while using pix-optimizer.

## Problem

Arrow keys (↑↓/←→) and Escape don't work inside the `/optimizer` overlay
when running under Ghostty Only `q` (close), space, and `h`/`j`/`k`/`l` aliases respond.

### Reproduction

1. Open pi in Ghostty
2. Run `/optimizer`
3. Press ↑/↓ or Esc — nothing happens
4. Press `q`, space, or `h`/`j`/`k`/`l` — these work as expected

**Environment:** Ghostty 1.3.1, pi-coding-agent 0.80.10, Linux,
`@xynogen/pix-optimizer` 1.1.18 (latest at time of writing)

## Root cause

`opt.ts`'s `handleInput` matched raw, hardcoded legacy ANSI escape
sequences for arrows and Escape (e.g. `"\u001b[A"` for up, bare `"\u001b"`
for escape). Under the Kitty keyboard protocol, these keys are not
necessarily sent in that legacy form, so none of the conditions matched
and the handler silently no-op'd (`else return;`).

## Fix

Import `matchesKey` from `@earendil-works/pi-tui` (already a declared
peerDependency, and already used the same way in `pix-models`) and use it
to match `"up"`, `"down"`, `"left"`, `"right"`, and `"escape"` instead of
hardcoded legacy sequences.
So this fixes the overlay under
Ghostty without changing behavior anywhere it already worked.

## Testing
-  bun run check + typecheck ok
- `bun test packages/pix-optimizer` : 156/156 existing tests pass
- Manually verified in Ghostty : arrows and Esc now work in the
  `/optimizer` overlay
