### PR TITLE
fix: make 'format' parameter optional in 'fetch' tool

### DIFF
--- a/packages/pix-9router/src/fetch.ts
+++ b/packages/pix-9router/src/fetch.ts
@@ -304,10 +304,12 @@ export default function registerFetch(pi: ExtensionAPI): void {
 		),
 		parameters: Type.Object({
 			url: Type.String({ description: "URL to fetch" }),
-			format: StringEnum(["markdown", "text", "html"] as const, {
-				description:
-					'Required choice. Enter exactly "markdown" for readable Markdown, "text" for plain text, or "html" for raw HTML.',
-			}),
+			format: Type.Optional(
+				StringEnum(["markdown", "text", "html"] as const, {
+					description:
+						'Optional choice. Enter exactly "markdown" for readable Markdown, "text" for plain text, or "html" for raw HTML. Default is "markdown".',
+				})
+			),
 			max_characters: Type.Optional(
 				Type.Number({
 					description: "Max characters (default 1000, 0 = unlimited)",

--- a/packages/pix-9router/src/fetch.ts
+++ b/packages/pix-9router/src/fetch.ts
@@ -245,13 +245,13 @@ export default function registerFetch(pi: ExtensionAPI): void {
 				StringEnum(["markdown", "text", "html"] as const, {
 					description:
 						'Optional choice. Enter exactly "markdown" for readable Markdown, "text" for plain text, or "html" for raw HTML. Default is "markdown".',
-				})
+				}),
 			),
 			max_characters: Type.Optional(
 				Type.Number({
 					description: "Max characters (default 1000, 0 = unlimited)",
 					default: 1000,
-				})
+				}),
 			),
 		}),
 

--- a/packages/pix-9router/src/fetch.ts
+++ b/packages/pix-9router/src/fetch.ts
@@ -251,7 +251,7 @@ export default function registerFetch(pi: ExtensionAPI): void {
 				Type.Number({
 					description: "Max characters (default 1000, 0 = unlimited)",
 					default: 1000,
-				}),
+				})
 			),
 		}),
 

--- a/packages/pix-9router/src/fetch.ts
+++ b/packages/pix-9router/src/fetch.ts
@@ -241,10 +241,12 @@ export default function registerFetch(pi: ExtensionAPI): void {
 		),
 		parameters: Type.Object({
 			url: Type.String({ description: "URL to fetch" }),
-			format: StringEnum(["markdown", "text", "html"] as const, {
-				description:
-					'Required choice. Enter exactly "markdown" for readable Markdown, "text" for plain text, or "html" for raw HTML.',
-			}),
+			format: Type.Optional(
+				StringEnum(["markdown", "text", "html"] as const, {
+					description:
+						'Optional choice. Enter exactly "markdown" for readable Markdown, "text" for plain text, or "html" for raw HTML. Default is "markdown".',
+				})
+			),
 			max_characters: Type.Optional(
 				Type.Number({
 					description: "Max characters (default 1000, 0 = unlimited)",


### PR DESCRIPTION
This PR updates the 'fetch' tool definition in 'pix-9router' to make the 'format' parameter optional, aligning it with the upstream 9Router API specification and the existing internal logic of 'executeFetch'.

Previously, the schema validator strictly enforced the presence of the 'format' parameter, causing valid requests (which rely on the 'markdown' default) to fail with a validation error. The 'executeFetch' function already correctly implements the 'markdown' default ('params.format ?? "markdown"'), so this change simply synchronizes the validator schema with the existing implementation and upstream documentation.

Changes:
- Modified 'packages/pix-9router/src/fetch.ts' to wrap the 'format' parameter definition in 'Type.Optional'.
- Updated the parameter description to clarify that 'format' is optional and defaults to 'markdown'.
- Added missing trailing commas to satisfy Biome formatting rules.