### PR TITLE
fix(pix-bash): collapse failed command results

### DIFF
--- a/packages/pix-bash/src/bash.test.ts
+++ b/packages/pix-bash/src/bash.test.ts
@@ -6,6 +6,7 @@ import type {
 	RenderContextLike,
 	TextComponentCtor,
 	ThemeLike,
+	ToolResultLike,
 } from "@xynogen/pix-pretty/types";
 import { formatBashDuration, registerBashTool, summarizeBashCommand } from "./bash";
 
@@ -272,5 +273,56 @@ describe("registerBashTool", () => {
 		expect(render({ timer: 1 })).toContain(diagnostic);
 		expect(render({ collapsed: true })).toContain("✗ bash bun test · exit 1");
 		expect(render({ collapsed: true }, true)).toContain(diagnostic);
+	});
+
+	it("collapses a non-zero exit thrown by Pi's built-in bash tool", async () => {
+		const registered: {
+			execute?: (...args: unknown[]) => Promise<ToolResultLike & { isError?: boolean }>;
+			renderResult?: (...args: unknown[]) => MockTextComponent;
+		} = {};
+		const mockPi: PiPrettyApi = {
+			registerTool(tool: unknown) {
+				Object.assign(registered, tool);
+			},
+			registerCommand() {},
+			on() {},
+		};
+		registerBashTool(
+			mockPi,
+			() => ({
+				execute: async () => {
+					throw new Error("test failed\n\nCommand exited with code 1");
+				},
+			}),
+			{
+				cwd: process.cwd(),
+				sp: (p: string) => p,
+				TextComponent: MockTextComponent as unknown as TextComponentCtor,
+				fffState: { module: null, finder: null, partialIndex: false, dbDir: null },
+				cursorStore: { store: () => "", get: () => undefined } as unknown as CursorStore,
+			},
+		);
+
+		const result = await registered.execute!(
+			"call-1",
+			{ command: "bun test" },
+			undefined,
+			undefined,
+			{},
+		);
+		expect(result.isError).toBe(true);
+		expect(result.details).toMatchObject({ _type: "bashResult", exitCode: 1 });
+
+		const theme: ThemeLike = {
+			fg: (_key: string, value: string) => value,
+			bold: (value: string) => value,
+		};
+		const rendered = registered.renderResult?.(result, { isPartial: false }, theme, {
+			expanded: false,
+			isError: true,
+			invalidate: () => {},
+			state: { collapsed: true },
+		} as unknown as RenderContextLike);
+		expect(rendered?.getText()).toContain("✗ bash bun test · exit 1");
 	});
 });

--- a/packages/pix-bash/src/bash.ts
+++ b/packages/pix-bash/src/bash.ts
@@ -80,27 +80,37 @@ export function registerBashTool(
 			toolCtx: ExtensionContext,
 		) {
 			const startedAt = Date.now();
-			const result = (await origBash.execute(tid, params, sig, upd, toolCtx)) as ToolResultLike;
-			const textContent = getTextContent(result);
+			const details = (text: string) => {
+				const exitMatch = text.match(/(?:exit code|exited with(?: code)?|exit status)[:\s]*(\d+)/i);
+				const exitCode = exitMatch
+					? Number(exitMatch[1])
+					: text.includes("command not found") || text.includes("No such file")
+						? 1
+						: 0;
+				return {
+					_type: "bashResult" as const,
+					text,
+					exitCode,
+					command: params.command ?? "",
+					durationMs: Date.now() - startedAt,
+				};
+			};
 
-			let exitCode: number | null = 0;
-			if (textContent) {
-				const exitMatch = textContent.match(/(?:exit code|exited with|exit status)[:\s]*(\d+)/i);
-				if (exitMatch) exitCode = Number(exitMatch[1]);
-				if (textContent.includes("command not found") || textContent.includes("No such file")) {
-					exitCode = 1;
+			try {
+				const result = (await origBash.execute(tid, params, sig, upd, toolCtx)) as ToolResultLike;
+				setResultDetails(result, details(getTextContent(result)));
+				return result;
+			} catch (error) {
+				const text = error instanceof Error ? error.message : String(error);
+				if (!/(?:exit code|exited with(?: code)?|exit status)[:\s]*(\d+)/i.test(text)) {
+					throw error;
 				}
+				return {
+					content: [{ type: "text" as const, text }],
+					details: details(text),
+					isError: true,
+				};
 			}
-
-			setResultDetails(result, {
-				_type: "bashResult",
-				text: textContent ?? "",
-				exitCode,
-				command: params.command ?? "",
-				durationMs: Date.now() - startedAt,
-			});
-
-			return result;
 		},
 
 		renderCall(args: BashParams, theme: ThemeLike, renderCtx: RenderContextLike) {


### PR DESCRIPTION
## Problem

`pix-bash` only attaches `_type: "bashResult"` details when Pi built-in `bash` resolves. Pi throws for completed commands with non-zero exits, so renderer receives unstructured errors and collapse policy cannot recognize them.

## Reproduce

1. Enable `pix-bash` with collapse enabled (default delay: 10 seconds).
2. Run a command Pi completes with exit code 1, for example `bun test` with a failing assertion.
3. Wait past collapse delay.

## Current TUI Result

Failed command remains expanded as a full error card containing `Command exited with code 1`. Full diagnostics remain visible, but completed card does not collapse.

## Expected TUI Result

After configured delay, TUI shows compact row such as `✗ bash bun test · exit 1`. Expanding row restores exact command diagnostics. Partial output and unrelated host errors retain existing behavior.

## Fix

Treat only thrown errors containing a recognized exit code as structured `bashResult` errors. Re-throw all other errors unchanged.

## Tests

- Added regression test for Pi thrown `Command exited with code 1` path.
- `bun test packages/pix-bash/src/bash.test.ts`
- `bun run check`
- `bun run typecheck`