### PR TITLE
fix(pretty): fit tools to Pi viewport

### DIFF
--- a/packages/pix-bash/src/extension.ts
+++ b/packages/pix-bash/src/extension.ts
@@ -5,7 +5,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { CursorStore, fffState } from "@xynogen/pix-pretty/fff";
 import type { PiPrettyApi, TextComponentCtor, ToolFactory } from "@xynogen/pix-pretty/types";
-import { shortPath } from "@xynogen/pix-pretty/utils";
+import { shortPath, viewportTextConstructor } from "@xynogen/pix-pretty/utils";
 import { once } from "@xynogen/pix-runtime/once";
 import { registerBashTool } from "./bash.js";
 
@@ -28,7 +28,7 @@ export default function pixBashExtension(pi: PiPrettyApi): void {
 		registerBashTool(pi, createBashTool, {
 			cwd,
 			sp: (p: string) => shortPath(cwd, home, p),
-			TextComponent,
+			TextComponent: viewportTextConstructor(TextComponent),
 			fffState,
 			cursorStore: new CursorStore(),
 		});

--- a/packages/pix-edit/src/extension.ts
+++ b/packages/pix-edit/src/extension.ts
@@ -6,7 +6,7 @@ import {
 import { CursorStore, fffState } from "@xynogen/pix-pretty/fff";
 import { attachResizeListener, trackInvalidator } from "@xynogen/pix-pretty/resize";
 import type { PiPrettyApi, TextComponentCtor, ToolFactory } from "@xynogen/pix-pretty/types";
-import { shortPath } from "@xynogen/pix-pretty/utils";
+import { shortPath, viewportTextConstructor } from "@xynogen/pix-pretty/utils";
 import { once } from "@xynogen/pix-runtime/once";
 import { registerEditTool } from "./edit.js";
 
@@ -34,7 +34,7 @@ export default function pixEditExtension(pi: PiPrettyApi): void {
 			{
 				cwd,
 				sp: (p: string) => shortPath(cwd, home, p),
-				TextComponent,
+				TextComponent: viewportTextConstructor(TextComponent),
 				fffState,
 				cursorStore: new CursorStore(),
 			},

--- a/packages/pix-find/src/extension.ts
+++ b/packages/pix-find/src/extension.ts
@@ -5,7 +5,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { CursorStore, fffState } from "@xynogen/pix-pretty/fff";
 import type { PiPrettyApi, TextComponentCtor, ToolFactory } from "@xynogen/pix-pretty/types";
-import { shortPath } from "@xynogen/pix-pretty/utils";
+import { shortPath, viewportTextConstructor } from "@xynogen/pix-pretty/utils";
 import { once } from "@xynogen/pix-runtime/once";
 import { registerFindTool } from "./find.js";
 
@@ -28,7 +28,7 @@ export default function pixFindExtension(pi: PiPrettyApi): void {
 		registerFindTool(pi, createFindTool, {
 			cwd,
 			sp: (p: string) => shortPath(cwd, home, p),
-			TextComponent,
+			TextComponent: viewportTextConstructor(TextComponent),
 			fffState,
 			cursorStore: new CursorStore(),
 		});

--- a/packages/pix-grep/src/extension.ts
+++ b/packages/pix-grep/src/extension.ts
@@ -21,7 +21,7 @@ import type {
 	TextComponentCtor,
 	ToolFactory,
 } from "@xynogen/pix-pretty/types";
-import { getErrorMessage, shortPath } from "@xynogen/pix-pretty/utils";
+import { getErrorMessage, shortPath, viewportTextConstructor } from "@xynogen/pix-pretty/utils";
 import { once } from "@xynogen/pix-runtime/once";
 import { registerGrepTool } from "./grep.js";
 
@@ -97,7 +97,7 @@ export default function pixGrepExtension(pi: PiPrettyApi): void {
 		registerGrepTool(pi, createGrepTool, {
 			cwd,
 			sp: (p: string) => shortPath(cwd, home, p),
-			TextComponent,
+			TextComponent: viewportTextConstructor(TextComponent),
 			fffState,
 			cursorStore,
 		});

--- a/packages/pix-ls/src/extension.ts
+++ b/packages/pix-ls/src/extension.ts
@@ -5,7 +5,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { CursorStore, fffState } from "@xynogen/pix-pretty/fff";
 import type { PiPrettyApi, TextComponentCtor, ToolFactory } from "@xynogen/pix-pretty/types";
-import { shortPath } from "@xynogen/pix-pretty/utils";
+import { shortPath, viewportTextConstructor } from "@xynogen/pix-pretty/utils";
 import { once } from "@xynogen/pix-runtime/once";
 import { registerLsTool } from "./ls.js";
 
@@ -28,7 +28,7 @@ export default function pixLsExtension(pi: PiPrettyApi): void {
 		registerLsTool(pi, createLsTool, {
 			cwd,
 			sp: (p: string) => shortPath(cwd, home, p),
-			TextComponent,
+			TextComponent: viewportTextConstructor(TextComponent),
 			fffState,
 			cursorStore: new CursorStore(),
 		});

--- a/packages/pix-pretty/src/types.ts
+++ b/packages/pix-pretty/src/types.ts
@@ -42,9 +42,11 @@ export type ToolContent = TextContent | ImageContent;
 
 export type ToolResultLike<TDetails = unknown> = AgentToolResult<TDetails | undefined>;
 
-type TextComponentLike = {
+export type TextComponentLike = {
 	setText(value: string): void;
 	getText?: () => string;
+	render?: (width: number) => string[];
+	invalidate?: () => void;
 };
 
 export type TextComponentCtor = new (text?: string, x?: number, y?: number) => TextComponentLike;

--- a/packages/pix-pretty/src/utils.test.ts
+++ b/packages/pix-pretty/src/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { MAX_PREVIEW_LINES } from "./config.js";
 import type { FgTheme } from "./types.js";
 import {
+	fillToolBackground,
 	formatCollapsedToolRow,
 	formatJson,
 	hideCollapsedToolCall,
@@ -11,7 +12,32 @@ import {
 	renderDimPreview,
 	ruleFrame,
 	setResultDetails,
+	viewportText,
 } from "./utils.js";
+
+class MockTextComponent {
+	private text = "";
+
+	setText(value: string): void {
+		this.text = value;
+	}
+
+	render(): string[] {
+		return this.text.split("\n");
+	}
+
+	invalidate(): void {}
+}
+
+describe("viewportText", () => {
+	it("trims a pre-filled row to Pi's narrower fullscreen viewport", () => {
+		const text = viewportText(MockTextComponent);
+		text.setText(fillToolBackground("tool", "", 10));
+
+		expect(plain(text.render(9)[0]!)).toBe("tool".padEnd(9));
+		expect(plain(text.render(10)[0]!)).toBe("tool".padEnd(10));
+	});
+});
 
 // Strip ANSI escapes so assertions test content, not color codes.
 const ANSI = /\x1b\[[0-9;]*m/g;

--- a/packages/pix-pretty/src/utils.ts
+++ b/packages/pix-pretty/src/utils.ts
@@ -14,6 +14,8 @@ import {
 import { MAX_PREVIEW_LINES } from "./config.js";
 import type {
 	FgTheme,
+	TextComponentCtor,
+	TextComponentLike,
 	ToolContent,
 	ToolImageContent,
 	ToolResultLike,
@@ -46,6 +48,53 @@ export function fillToolBackground(text: string, bg = BG_BASE, width?: number): 
 			return `${bg}${fitted}${" ".repeat(padding)}${RST}`;
 		})
 		.join("\n");
+}
+
+export function viewportTextConstructor(TextComponent: TextComponentCtor): TextComponentCtor {
+	return function ViewportTextComponent(text = "") {
+		const component = viewportText(TextComponent);
+		component.setText(text);
+		return component;
+	} as unknown as TextComponentCtor;
+}
+
+export function viewportText(
+	TextComponent: TextComponentCtor,
+): TextComponentLike & ViewportComponent {
+	return new ViewportText(new TextComponent("", 0, 0));
+}
+
+type ViewportComponent = {
+	render(width: number): string[];
+	invalidate(): void;
+};
+
+class ViewportText implements TextComponentLike, ViewportComponent {
+	private text = "";
+
+	constructor(private readonly component: TextComponentLike) {}
+
+	setText(value: string): void {
+		this.text = value;
+		this.component.setText(value);
+	}
+
+	getText(): string {
+		return this.text;
+	}
+
+	render(width: number): string[] {
+		const fitted = this.text
+			.split("\n")
+			.map((line) => truncateToWidth(line, width, ""))
+			.join("\n");
+		this.component.setText(fitted);
+		return this.component.render?.(width) ?? fitted.split("\n");
+	}
+
+	invalidate(): void {
+		this.component.invalidate?.();
+	}
 }
 
 export function pluralize(count: number, noun: string, plural?: string): string {

--- a/packages/pix-read/src/extension.ts
+++ b/packages/pix-read/src/extension.ts
@@ -5,7 +5,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { CursorStore, fffState } from "@xynogen/pix-pretty/fff";
 import type { PiPrettyApi, TextComponentCtor, ToolFactory } from "@xynogen/pix-pretty/types";
-import { shortPath } from "@xynogen/pix-pretty/utils";
+import { shortPath, viewportTextConstructor } from "@xynogen/pix-pretty/utils";
 
 import { once } from "@xynogen/pix-runtime/once";
 import { registerReadTool } from "./read.js";
@@ -29,7 +29,7 @@ export default function pixReadExtension(pi: PiPrettyApi): void {
 		registerReadTool(pi, createReadTool, {
 			cwd,
 			sp: (p: string) => shortPath(cwd, home, p),
-			TextComponent,
+			TextComponent: viewportTextConstructor(TextComponent),
 			fffState,
 			cursorStore: new CursorStore(),
 		});

--- a/packages/pix-write/src/extension.ts
+++ b/packages/pix-write/src/extension.ts
@@ -6,7 +6,7 @@ import {
 import { CursorStore, fffState } from "@xynogen/pix-pretty/fff";
 import { attachResizeListener, trackInvalidator } from "@xynogen/pix-pretty/resize";
 import type { PiPrettyApi, TextComponentCtor, ToolFactory } from "@xynogen/pix-pretty/types";
-import { shortPath } from "@xynogen/pix-pretty/utils";
+import { shortPath, viewportTextConstructor } from "@xynogen/pix-pretty/utils";
 
 import { once } from "@xynogen/pix-runtime/once";
 import { registerWriteTool } from "./write.js";
@@ -35,7 +35,7 @@ export default function pixWriteExtension(pi: PiPrettyApi): void {
 			{
 				cwd,
 				sp: (p: string) => shortPath(cwd, home, p),
-				TextComponent,
+				TextComponent: viewportTextConstructor(TextComponent),
 				fffState,
 				cursorStore: new CursorStore(),
 			},


### PR DESCRIPTION
## Problem

`pix-pretty` pads self-rendered tool rows to terminal width. Pi fullscreen `ScrollView` reserves last column when scrollbar is `always`, so child viewport is one cell narrower. Tool frames overflow by one column.

## Reproduce

1. Enable `pix-pretty` tools.
2. Set Pi fullscreen scrollbar to `always`.
3. Enter fullscreen mode.
4. Run `bash`, `read`, `edit`, `find`, `grep`, `ls`, or `write`.

## Current TUI Result

Tool background, rules, previews, or diffs render one cell beyond fullscreen content viewport.

## Expected TUI Result

Tool output fits supplied Pi component width. Regular terminal mode keeps full terminal width.

## Fix

Wrap native `TextComponent` at extension registration. On `render(width)`, truncate each ANSI-aware line to Pi viewport width. Keep original text for future wider renders.

## Tests

- Added fullscreen viewport-width regression test.
- `bun test packages/pix-pretty/src/utils.test.ts ...focused tool tests`
- `bun run typecheck`
- `bunx biome check <changed paths>`