### PR TITLE
docs(pix-mcp): add optional Parallel Search setup

### DIFF
--- a/packages/pix-mcp/README.md
+++ b/packages/pix-mcp/README.md
@@ -25,10 +25,20 @@ Preferred project config: `.mcp.json`
     "chrome-devtools": {
       "command": "npx",
       "args": ["-y", "chrome-devtools-mcp@latest"]
+    },
+    "parallel-search": {
+      "url": "https://search.parallel.ai/mcp"
     }
   }
 }
 ```
+
+After explicitly installing the extension, choose the personal project
+`.mcp.json` above to opt in to Parallel Search MCP. It needs no Parallel account
+or API key. The optional server follows the default lazy lifecycle and does not
+change provider selection, defaults, or other configured servers. When its tools
+are used, user-provided search objectives, search queries, and requested URLs
+are sent to Parallel.
 
 Preferred shared user config: `~/.config/mcp/mcp.json`.
 


### PR DESCRIPTION
## Why

Pix MCP users can opt into web search and URL fetching through the existing project-scoped `.mcp.json` extension point. The Parallel Search MCP endpoint requires no account or API key.

## Changes

- Add an optional `parallel-search` URL-only server alongside the existing Chrome DevTools entry.
- Preserve Pix MCP's lazy lifecycle, provider selection, defaults, and existing configured servers.
- Disclose that user-provided search objectives, search queries, and requested URLs are sent to Parallel when its tools are used.

## Validation

- Parsed the documented JSON and verified the exact URL-only shape and preserved Chrome DevTools entry.
- `git diff --check`: passed.
- Verified `packages/pix-mcp/README.md` is the only changed path.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.