### PR TITLE
feat(pix-9router): add refreshModels and non-blocking startup registration

### DIFF
--- a/packages/pix-9router/src/provider.ts
+++ b/packages/pix-9router/src/provider.ts
@@ -9,6 +9,7 @@
  *   ROUTER_API_KEY   — bearer token (required for live model list)
  */
 
+import type { RefreshModelsContext } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ModelsDevModel, RouterModel } from "./data.js";
 import { fetchModelsDevIndex, lookupInIndex, routerBaseUrl, routerModels } from "./data.js";
@@ -25,6 +26,33 @@ const ZERO_COST = {
 
 // Fallback pattern-based detection if models.dev lookup fails
 const IMAGE_CAPABLE_PATTERNS = [/claude/i, /gpt-5/i, /gpt-4/i, /kimi-k2/i, /hy3/i];
+
+interface RouterModelsResponse {
+	data?: RouterModel[];
+}
+
+const COMPAT = {
+	supportsDeveloperRole: false,
+	supportsUsageInStreaming: false,
+	maxTokensField: "max_tokens",
+} as const;
+
+function toModelConfig(devIndex: Map<string, ModelsDevModel>) {
+	return (model: RouterModel) => {
+		const id = model.id ?? "";
+		const devModel = lookupInIndex(id, devIndex);
+		return {
+			id,
+			name: getModelName(model, devModel),
+			reasoning: getReasoning(model, devModel),
+			input: getInputTypes(model, devModel),
+			cost: ZERO_COST,
+			contextWindow: getContextWindow(model, devModel),
+			maxTokens: getMaxTokens(model, devModel),
+			compat: COMPAT,
+		};
+	};
+}
 
 export function getInputTypes(model: RouterModel, devModel?: ModelsDevModel): ("text" | "image")[] {
 	if (devModel?.modalities?.input) {
@@ -82,39 +110,54 @@ export default async function registerProvider(pi: ExtensionAPI): Promise<void> 
 		return;
 	}
 
-	const [models, devIndex] = await Promise.all([
+	// Upstream moved OpenAI `compat` settings from the provider level to the
+	// per-model level (ProviderModelConfig.compat). Applied in toModelConfig.
+
+	// Register from disk cache only — startup must not block on network.
+	const cached = routerModels.getCached();
+	pi.registerProvider("9router", providerConfig(apiKey, cached, new Map()));
+
+	// Background refresh; re-registering after startup applies immediately.
+	void Promise.all([
 		routerModels.get(),
 		fetchModelsDevIndex().catch(() => new Map<string, ModelsDevModel>()),
-	]);
+	])
+		.then(([models, devIndex]) =>
+			pi.registerProvider("9router", providerConfig(apiKey, models, devIndex)),
+		)
+		.catch(() => {});
+}
 
-	// Upstream moved OpenAI `compat` settings from the provider level to the
-	// per-model level (ProviderModelConfig.compat). Apply the same shim to every
-	// registered model.
-	const COMPAT = {
-		supportsDeveloperRole: false,
-		supportsUsageInStreaming: false,
-		maxTokensField: "max_tokens",
-	} as const;
-
-	pi.registerProvider("9router", {
+function providerConfig(
+	apiKey: string,
+	models: RouterModel[],
+	devIndex: Map<string, ModelsDevModel>,
+) {
+	return {
 		name: "9Router",
 		baseUrl: routerBaseUrl(),
 		apiKey: "$ROUTER_API_KEY",
 		api: "openai-completions",
 		headers: { "User-Agent": "pi-coding-agent" },
-		models: models.map((model) => {
-			const id = model.id ?? "";
-			const devModel = lookupInIndex(id, devIndex);
-			return {
-				id,
-				name: getModelName(model, devModel),
-				reasoning: getReasoning(model, devModel),
-				input: getInputTypes(model, devModel),
-				cost: ZERO_COST,
-				contextWindow: getContextWindow(model, devModel),
-				maxTokens: getMaxTokens(model, devModel),
-				compat: COMPAT,
-			};
-		}),
-	});
+		models: models.map(toModelConfig(devIndex)),
+		// Live fetch on /model refresh — bypasses the disk cache.
+		// Pi calls refreshModels once per provider at every startup with
+		// allowNetwork:false (awaited, no timeout) — never touch the network
+		// there; serve the registered snapshot instead.
+		async refreshModels({ signal, allowNetwork }: RefreshModelsContext) {
+			if (!allowNetwork) return models.map(toModelConfig(devIndex));
+			const res = await fetch(`${routerBaseUrl()}/models`, {
+				signal: AbortSignal.any([AbortSignal.timeout(8_000), ...(signal ? [signal] : [])]),
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"User-Agent": "pi-coding-agent",
+				},
+			});
+			if (!res.ok) throw new Error(`9router /models: ${res.status}`);
+			const raw = (await res.json()) as RouterModelsResponse;
+			const list = (raw.data ?? []).filter((m) => Boolean(m.id));
+			const fresh = await fetchModelsDevIndex().catch(() => new Map<string, ModelsDevModel>());
+			return list.map(toModelConfig(fresh));
+		},
+	};
 }


### PR DESCRIPTION
## Problem

1. **Stale model list in `/model`.** The extension registers a static `models`
   array at startup and never implements `refreshModels`. Pi's
   "Model catalogs refreshed." only re-queries providers that implement
   `refreshModels`, so the 9router list stays frozen at whatever was fetched
   when Pi started — even after models change upstream.

2. **Slow startup after the cache TTL expires.** `registerProvider` awaits
   `routerModels.get()` and `fetchModelsDevIndex()` (a ~484KB modelgrep
   download, 24h TTL) before registering. Once the cache goes stale, every
   Pi startup blocks on these network requests.

## Changes

- **Non-blocking startup**: register the provider immediately from the disk
  cache via `routerModels.getCached()` (sync file read, no network), then
  fetch fresh data in the background and re-register. Pi applies
  post-startup registrations immediately, so no `/reload` is needed.
- **`refreshModels({ signal, allowNetwork })`**:
  - When Pi calls it during startup's offline phase (`allowNetwork: false`,
    awaited with no timeout), return the registered snapshot without any
    network access — otherwise every startup pays a live request to the
    router, which can take ~10s on a cold connection.
  - On an explicit `/model` catalog refresh (`allowNetwork: true`), fetch
    `GET {ROUTER_API_BASE}/models` live (8s timeout), so the model list
    always tracks the upstream router.
- Extracted `COMPAT` / `toModelConfig()` / `providerConfig()` so both the
  initial registration and the background re-registration share one config
  builder.

## Verification

- `tsc --noEmit -p tsconfig.base.json` and `biome check` clean.
- `bun test packages/pix-9router/`: 133 pass / 10 fail — identical to the
  upstream baseline (the 10 failures are pre-existing environment-related
  failures, unrelated to this change).
- Manually confirmed on Pi: startup performs zero router requests, and
  /model refresh picks up upstream model changes immediately.