### PR TITLE
fix(pix-9router): use ioTimeoutSignal instead of hardcoded 8s refresh timeout

### DIFF
--- a/packages/pix-9router/src/provider.ts
+++ b/packages/pix-9router/src/provider.ts
@@ -11,6 +11,7 @@
 
 import type { RefreshModelsContext } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { ioTimeoutSignal } from "@xynogen/pix-runtime/io";
 import type { ModelsDevModel, RouterModel } from "./data.js";
 import { fetchModelsDevIndex, lookupInIndex, routerBaseUrl, routerModels } from "./data.js";
 
@@ -147,7 +148,7 @@ function providerConfig(
 		async refreshModels({ signal, allowNetwork }: RefreshModelsContext) {
 			if (!allowNetwork) return models.map(toModelConfig(devIndex));
 			const res = await fetch(`${routerBaseUrl()}/models`, {
-				signal: AbortSignal.any([AbortSignal.timeout(8_000), ...(signal ? [signal] : [])]),
+				signal: ioTimeoutSignal(signal),
 				headers: {
 					Authorization: `Bearer ${apiKey}`,
 					"User-Agent": "pi-coding-agent",


### PR DESCRIPTION
## Problem

The 0.4.0 `refreshModels` implementation wraps its fetch in a hardcoded `AbortSignal.timeout(8_000)`. On slow routes to the router endpoint, the 8s cap always fires first, so `/model` → refresh fails every time with "Could not refresh 9router; showing cached models."

## Changes

Replace the hardcoded cap with the shared pix-runtime IO timeout: ioTimeoutSignal

- Default 30s, configurable via pix-runtime's `io` section — consistent with how the extension's own DataSource fetches are already bounded.
- Still combined with the caller's abort signal (e.g. the model selector's own 15s window keeps `/model` responsive).

## Verification

- `tsc --noEmit -p tsconfig.base.json` and `biome check` clean.
- Manual: `/model` refresh against a ~13.5s router endpoint now succeeds instead of always aborting at 8s.